### PR TITLE
[FEAT] 인기 검색 공연장 조회 API 구현 (#14)

### DIFF
--- a/src/main/java/com/umc/connext/domain/venue/controller/VenueController.java
+++ b/src/main/java/com/umc/connext/domain/venue/controller/VenueController.java
@@ -1,0 +1,29 @@
+package com.umc.connext.domain.venue.controller;
+
+import com.umc.connext.common.code.SuccessCode;
+import com.umc.connext.common.response.Response;
+import com.umc.connext.domain.venue.dto.VenueResDTO;
+import com.umc.connext.domain.venue.service.VenueService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/venues")
+public class VenueController implements VenueControllerDocs{
+
+    private final VenueService venueService;
+    // 인기 검색 공연장 조회
+    @GetMapping("/trend-search")
+    public ResponseEntity<Response<List<VenueResDTO.VenuePreviewDTO>>> trendSearchVenues() {
+        List<VenueResDTO.VenuePreviewDTO> result = venueService.trendSearchVenues();
+
+        return ResponseEntity.ok().body(Response.success(SuccessCode.GET_SUCCESS, result, "인기 검색 공연장 조회 성공"));
+    }
+
+}

--- a/src/main/java/com/umc/connext/domain/venue/controller/VenueControllerDocs.java
+++ b/src/main/java/com/umc/connext/domain/venue/controller/VenueControllerDocs.java
@@ -1,0 +1,28 @@
+package com.umc.connext.domain.venue.controller;
+
+import com.umc.connext.common.response.Response;
+import com.umc.connext.domain.venue.dto.VenueResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@RequestMapping("/venues")
+public interface VenueControllerDocs {
+
+    // 인기 검색 공연장 조회
+    @Operation(
+            summary = "인기 검색 공연장 조회",
+            description = "검색 횟수가 가장 많은 공연장 5개를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    @GetMapping("/trend-search")
+    ResponseEntity<Response<List<VenueResDTO.VenuePreviewDTO>>> trendSearchVenues();
+
+}

--- a/src/main/java/com/umc/connext/domain/venue/converter/VenueConverter.java
+++ b/src/main/java/com/umc/connext/domain/venue/converter/VenueConverter.java
@@ -1,0 +1,20 @@
+package com.umc.connext.domain.venue.converter;
+
+import com.umc.connext.domain.venue.dto.VenueResDTO;
+import com.umc.connext.domain.venue.entity.Venue;
+
+public class VenueConverter {
+
+    // Entity -> DTO
+    public static VenueResDTO.VenuePreviewDTO toVenuePreviewDTO(
+            Venue venue
+    ){
+        return VenueResDTO.VenuePreviewDTO.builder()
+                .id(venue.getId())
+                .name(venue.getName())
+                .city(venue.getCity())
+                .imageUrl(venue.getImageUrl())
+                .build();
+    }
+
+}

--- a/src/main/java/com/umc/connext/domain/venue/dto/VenueResDTO.java
+++ b/src/main/java/com/umc/connext/domain/venue/dto/VenueResDTO.java
@@ -1,0 +1,15 @@
+package com.umc.connext.domain.venue.dto;
+
+import lombok.Builder;
+
+public class VenueResDTO {
+
+    @Builder
+    public record VenuePreviewDTO(
+            Long id,
+            String name,
+            String city,
+            String imageUrl
+    ){}
+
+}

--- a/src/main/java/com/umc/connext/domain/venue/entity/Venue.java
+++ b/src/main/java/com/umc/connext/domain/venue/entity/Venue.java
@@ -1,0 +1,47 @@
+package com.umc.connext.domain.venue.entity;
+
+import com.umc.connext.common.entity.BaseEntity;
+import com.umc.connext.domain.venue.enums.VenueType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "venues")
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Venue extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private VenueType venueType = VenueType.CONCERT_HALL;
+
+    @Column(name = "total_views", nullable = false)
+    private Integer totalViews;
+
+    @Column(name = "search_count", nullable = false)
+    private Integer searchCount;
+}

--- a/src/main/java/com/umc/connext/domain/venue/enums/VenueType.java
+++ b/src/main/java/com/umc/connext/domain/venue/enums/VenueType.java
@@ -1,0 +1,5 @@
+package com.umc.connext.domain.venue.enums;
+
+public enum VenueType {
+    CONCERT_HALL, BASEBALL_STADIUM
+}

--- a/src/main/java/com/umc/connext/domain/venue/repository/VenueRepository.java
+++ b/src/main/java/com/umc/connext/domain/venue/repository/VenueRepository.java
@@ -1,0 +1,12 @@
+package com.umc.connext.domain.venue.repository;
+
+import com.umc.connext.domain.venue.entity.Venue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VenueRepository extends JpaRepository<Venue, Long> {
+
+    List<Venue> findTop5ByOrderBySearchCountDesc();
+
+}

--- a/src/main/java/com/umc/connext/domain/venue/service/VenueService.java
+++ b/src/main/java/com/umc/connext/domain/venue/service/VenueService.java
@@ -1,0 +1,32 @@
+package com.umc.connext.domain.venue.service;
+
+import com.umc.connext.domain.venue.repository.VenueRepository;
+import com.umc.connext.domain.venue.converter.VenueConverter;
+import com.umc.connext.domain.venue.dto.VenueResDTO;
+import com.umc.connext.domain.venue.entity.Venue;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VenueService {
+
+    private final VenueRepository venueRepository;
+
+    // 인기 검색 공연장 조회
+    @Transactional(readOnly = true)
+    public List<VenueResDTO.VenuePreviewDTO> trendSearchVenues() {
+
+        // searchCount가 가장 높은 것부터 5개 조회
+        List<Venue> top5BySearchCount = venueRepository.findTop5ByOrderBySearchCountDesc();
+
+        // DTO 변환
+        return top5BySearchCount.stream()
+                .map(VenueConverter::toVenuePreviewDTO)
+                .toList();
+    }
+
+}


### PR DESCRIPTION
* feat(trend-search-venues): #13 - Venue Entity 설정

* feat(trend-search-venues): #13 - Venue Entity에 searchCount Column 추가

* feat(trend-search-venues): #13 - VenuePreviewDTO 및 Converter 생성

* feat(trend-search-venues): #13 - searchCount가 가장 높은 공연장 5개 조회 구현

* refactor: repository 패키지 구조 정리

* refactor: trendSearch 메서드명을 trendSearchVenues로 변경

* fix: 불필요한 transactional 삭제

* refactor: venVenue Entity BaseEntity 상속, Type ENUM 이름을 VenueType으로 변경

* refactor: 조회 서비스에 readOnly 트랜잭션 복구

<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. yooniicode -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->



## ⚠️ PR 특이 사항




## 📚 Reference




### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
